### PR TITLE
Add chart showing spot vs on-demand usage for ECS/Fargate 

### DIFF
--- a/modules/dashboards/fargate/README.md
+++ b/modules/dashboards/fargate/README.md
@@ -1,0 +1,4 @@
+# Fargate dashboard
+
+Provides information about spot vs on-demand usage in Fargate (ECS) resources.
+Unfortunately those metrics are global and cannot be filtered to single cluster.

--- a/modules/dashboards/fargate/locals.tf
+++ b/modules/dashboards/fargate/locals.tf
@@ -10,13 +10,13 @@ locals {
 }
 
 module "name" {
-  source = "/modules/widgets/text"
+  source = "../../widgets/text"
 
   text = "Fargate Spot vs OnDemand"
 }
 
 module "vcpus" {
-  source = "/modules/widgets/value-chart"
+  source = "../../widgets/value-chart"
 
   name = "Fargate Spot vs OnDemand (${data.aws_region.current.name})"
   metrics = [

--- a/modules/dashboards/fargate/locals.tf
+++ b/modules/dashboards/fargate/locals.tf
@@ -1,0 +1,28 @@
+data "aws_region" "current" {}
+
+locals {
+  metrics = {
+    fargate = {
+      sport    = ["AWS/Usage", "ResourceCount", "Type", "Resource", "Resource", "vCPU", "Service", "Fargate", "Class", "Standard/Spot", { "region" : data.aws_region.current.name }],
+      ondemand = ["AWS/Usage", "ResourceCount", "Type", "Resource", "Resource", "vCPU", "Service", "Fargate", "Class", "Standard/OnDemand", { "region" : data.aws_region.current.name }]
+    }
+  }
+}
+
+module "name" {
+  source = "/modules/widgets/text"
+
+  text = "Fargate Spot vs OnDemand"
+}
+
+module "vcpus" {
+  source = "/modules/widgets/value-chart"
+
+  name = "Fargate Spot vs OnDemand (${data.aws_region.current.name})"
+  metrics = [
+    local.metrics.fargate.sport,
+    local.metrics.fargate.ondemand
+  ]
+}
+
+

--- a/modules/dashboards/fargate/outputs.tf
+++ b/modules/dashboards/fargate/outputs.tf
@@ -1,0 +1,8 @@
+output "widgets" {
+  description = "Widgets that can be combined within the dashboard"
+
+  value = concat(
+    [module.name.widget],
+    module.vcpus.widgets
+  )
+}


### PR DESCRIPTION
This adds a widget showing the spot vs on-demand usage for ECS/Fargate resources.