### PR TITLE
Unfortunately the widget object is more complex - changing it type to any

### DIFF
--- a/modules/dashboards/body/main.tf
+++ b/modules/dashboards/body/main.tf
@@ -4,7 +4,7 @@ variable "name" {
 }
 
 variable "widgets" {
-  type        = list(string)
+  type        = any
   description = "List of widgets to display on the dashboard"
 }
 


### PR DESCRIPTION
While passing dashboard widgets from various modules, it becomes tricky to get all objects in sync (they are not just strings/jsons). Therefore, changing the type to any